### PR TITLE
HW-1: Potential Edit for chemextensions function PCAAnalysis()

### DIFF
--- a/global_chem_extensions/global_chem_extensions/cheminformatics/applications/node_pca_analysis.py
+++ b/global_chem_extensions/global_chem_extensions/cheminformatics/applications/node_pca_analysis.py
@@ -127,7 +127,7 @@ class PCAAnalysis(object):
 
         kmean_data = dict(
             x=chemicalspace[:,0],
-            y=chemicalspace[:,2],
+            y=chemicalspace[:,1],
             img=[PCAAnalysis.mol2svg(m) for m in molecules_list],
             ids=[str(i) for i in range(0, len(self.smiles_list))],
             fill_color=kmeanc,


### PR DESCRIPTION
**Suggested Edit (should be generally helpful)**
Noticed that the default code appeared to plot PC1 and PC3, so updated to plot PC1 (`chemicalspace[:,0]`) and PC2 (`chemicalspace[:,1]`) as collectively, these should explain a higher proportion of the variance (versus just PC1 + PC3 (`chemicalspace[:,2])`).

**Suggested options (these were helpful to us; might be helpful for others)**
- We wanted to overlay the PC output with our own experimental data, so needed to export the PCs. 
-  Added code (using `pandas`) to output PCs to TSV. (with user option **save_pcs**).
- As a note: by outputting the first 3 PCs, we were able to see clearer separation when in a three dimensional plot.
- Updated so that the user-provided filename would be the same base name for the TSV and HTML. 
- (note: did not yet update `cheminformatics.py` with save_pcs option )

(Enjoyed using PCAAnalysis() and was able to successfully analyze a provided list of SMILES Ids! Found via Medium post. Thanks!)
