### PR TITLE
Output Percent of the Variance Explained and full PCs df

### DIFF
--- a/global_chem_extensions/global_chem_extensions/cheminformatics/applications/node_pca_analysis.py
+++ b/global_chem_extensions/global_chem_extensions/cheminformatics/applications/node_pca_analysis.py
@@ -184,11 +184,14 @@ class PCAAnalysis(object):
         principal_component_df = principal_component_df[ds['cols']]
         principal_component_df['smiles'] = self.smiles_list
 
+        pc_variance_expained_df=pd.DataFrame(pca.explained_variance_ratio_, columns=['Variance_Explained'])
+        pc_variance_expained_df['PC']=pc_variance_expained_df.index + 1 
+
         source = ColumnDataSource(kmean_data)
 
         plot = figure(
-            plot_width = self.plot_width,
-            plot_height = self.plot_height,
+            width = self.plot_width,
+            height = self.plot_height,
             tooltips = TOOLTIPS,
             title = self.title,
             x_axis_label = self.x_axis_label,
@@ -211,6 +214,7 @@ class PCAAnalysis(object):
             
         if self.save_principal_components:
             principal_component_df.to_csv((self.file_name + ".tsv"), sep="\t", index=False)
+            pc_variance_expained_df.to_csv((self.file_name + "Variance_Explained.tsv"), sep="\t", index=False)
 
         if self.return_mol_ids:
             return self.plot_mappings

--- a/global_chem_extensions/global_chem_extensions/cheminformatics/applications/node_pca_analysis.py
+++ b/global_chem_extensions/global_chem_extensions/cheminformatics/applications/node_pca_analysis.py
@@ -180,10 +180,15 @@ class PCAAnalysis(object):
             ]
         }
 
-        principal_component_df =pd.DataFrame(kmean_data)
-        principal_component_df = principal_component_df[ds['cols']]
-        principal_component_df['smiles'] = self.smiles_list
+        kmeans_df =pd.DataFrame(kmean_data)
+        kmeans_df = principal_component_df[ds['cols']]
+        kmeans_df['smiles'] = self.smiles_list
 
+        pc_df=pd.DataFrame(chemicalspace)
+        pc_df.columns=[f'PC{i}' for i in range(1, len(pc_df.columns) + 1) ]
+
+        pc_kmeans_df=pd.concat([kmeans_df,pc_df], axis=1)
+        
         pc_variance_expained_df=pd.DataFrame(pca.explained_variance_ratio_, columns=['Variance_Explained'])
         pc_variance_expained_df['PC']=pc_variance_expained_df.index + 1 
 
@@ -213,7 +218,7 @@ class PCAAnalysis(object):
             show(plot)
             
         if self.save_principal_components:
-            principal_component_df.to_csv((self.file_name + ".tsv"), sep="\t", index=False)
+            pc_kmeans_df.to_csv((self.file_name + ".tsv"), sep="\t", index=False)
             pc_variance_expained_df.to_csv((self.file_name + "Variance_Explained.tsv"), sep="\t", index=False)
 
         if self.return_mol_ids:

--- a/global_chem_extensions/global_chem_extensions/cheminformatics/applications/node_pca_analysis.py
+++ b/global_chem_extensions/global_chem_extensions/cheminformatics/applications/node_pca_analysis.py
@@ -181,7 +181,7 @@ class PCAAnalysis(object):
         }
 
         kmeans_df =pd.DataFrame(kmean_data)
-        kmeans_df = principal_component_df[ds['cols']]
+        kmeans_df = kmeans_df[ds['cols']]
         kmeans_df['smiles'] = self.smiles_list
 
         pc_df=pd.DataFrame(chemicalspace)


### PR DESCRIPTION
If save_principal_components =True, then:

- output a file that shows the percentage of the variance explained for each of the user-specified number_of_components.
- output the full list (number_of_components) of PCs, instead of just the first two used to make the plot. 

Updated  plot code for compatibility with newer bokeh version. (Renamed plot_width and plot_height to width and height, respectively). --see https://stackoverflow.com/questions/74280959/attributeerror-unexpected-attribute-plot-width-to-figure-similar-attributes 