### PR TITLE
Replace the package name rdkit-pypi with rdkit.

### DIFF
--- a/global_chem_extensions/requirements.txt
+++ b/global_chem_extensions/requirements.txt
@@ -1,6 +1,6 @@
 global-chem
 numpy
-rdkit-pypi
+rdkit
 pandas
 requests
 


### PR DESCRIPTION
When building the global-chem-extensions package on Python 3.12, you need to replace the package name rdkit-pypi with rdkit.